### PR TITLE
feat: rename to reroutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-![reroute logo](/logo.svg "React Router logo reimagined with the colour scheme of remodules logo")
+![reroutes logo](/logo.svg "React Router logo reimagined with the colour scheme of remodules logo")
 
-# `reroute` - Dynamic Module Loading for Your Redux Application
+# `reroutes` - Dynamic Module Loading for Your Redux Application
 
 ## Installation
 
 ```bash
-npm install --save reroute
+npm install --save reroutes
 ```
 
 ## Add Peer Dependencies
@@ -20,10 +20,10 @@ npm install --save remodules react-router @reduxjs/toolkit redux-saga # react re
 import { useSelector } from "react-redux";
 import { takeEvery } from "redux-saga/effects";
 import { createModule, useModule } from "remodules";
-import createReroute from "reroute";
+import createReroutes from "reroutes";
 
-const { reroute, useReroute, createLocationChangedMatcher } =
-  createReroute("test");
+const { reroutes, useReroutes, createLocationChangedMatcher } =
+  createReroutes("test");
 
 const exampleModule = createModule({
   name: "example",
@@ -49,8 +49,8 @@ const exampleModule = createModule({
 const Example = () => {
   useModule(exampleModule);
 
-  const action = useSelector(reroute.selectors.action);
-  const location = useSelector(reroute.selectors.location);
+  const action = useSelector(reroutes.selectors.action);
+  const location = useSelector(reroutes.selectors.location);
 
   const navigationCount = useSelector(exampleModule.selectors.count);
 
@@ -63,7 +63,7 @@ const Example = () => {
 };
 
 export const App = () => {
-  useReroute();
+  useReroutes();
 
   return (
     <div>
@@ -77,7 +77,7 @@ export const App = () => {
 
 For users of `remodules`, and `react-router`, this package makes it possible to respond to navigation events from your modules.
 
-When this module takes root in your project, it will check the base route where it was originally mounted via `useReroute` and will store the initial routing state as well as the base route in the store.
+When this module takes root in your project, it will check the base route where it was originally mounted via `useReroutes` and will store the initial routing state as well as the base route in the store.
 
 When the user navigates to a new route, the store will be updated with the new routing state.
 
@@ -85,7 +85,7 @@ This means you can use the root component for multiple different base routes wit
 
 ## How it works?
 
-- When you use `createReroute` function, which is the default export from the module, you specify a `key` string that is used to create a new module with that key. This ensures that different instances of this module will not get mixed up. When you create 2 modules with the same key, what will happen is that the second module will override the first module, which will mean that the state slice of that module will not match what you expect in your selectors.
-- The `useReroute` function mounts the module with the base path where it's used. The module will take root using the path from the base route. This means that you can "ignore" the base path (path that is used to mount the component where you called `useReroute`).
-- You can use the `reroute` module like any other `remodules` module in your code.
+- When you use `createReroutes` function, which is the default export from the module, you specify a `key` string that is used to create a new module with that key. This ensures that different instances of this module will not get mixed up. When you create 2 modules with the same key, what will happen is that the second module will override the first module, which will mean that the state slice of that module will not match what you expect in your selectors.
+- The `useReroutes` function mounts the module with the base path where it's used. The module will take root using the path from the base route. This means that you can "ignore" the base path (path that is used to mount the component where you called `useReroutes`).
+- You can use the `reroutes` module like any other `remodules` module in your code.
 - There's also a utility function that can help create route change matchers, called `createLocationChangedMatcher`. This function takes a path and an options object. This is passed into `"path-to-regexp"` and helps customise behaviour.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "reroute",
+  "name": "reroutes",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "reroute",
+      "name": "reroutes",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "reroute",
+  "name": "reroutes",
   "version": "1.0.0",
   "description": "React Router connected to Redux using Remodules",
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/superbet-group/reroute.git"
+    "url": "ssh://github.com/superbet-group/reroutes.git"
   },
   "files": [
     "dist",
@@ -14,14 +14,14 @@
     "LICENSE",
     "CONTRIBUTING.md"
   ],
-  "main": "dist/reroute.umd.js",
-  "unpkg": "dist/reroute.iife.js",
-  "jsdelivr": "dist/reroute.iife.js",
-  "module": "./dist/reroute.js",
+  "main": "dist/reroutes.umd.js",
+  "unpkg": "dist/reroutes.iife.js",
+  "jsdelivr": "dist/reroutes.iife.js",
+  "module": "./dist/reroutes.js",
   "exports": {
     ".": {
-      "import": "./dist/reroute.js",
-      "require": "./dist/reroute.umd.js"
+      "import": "./dist/reroutes.js",
+      "require": "./dist/reroutes.umd.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "scripts": {
     "build": "vite build && tsc",
     "dev": "vite",
-    "test": "vitest run"
+    "test": "vitest",
+    "coverage": "vitest run --coverage"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -5,19 +5,19 @@ import { createDynamicStore } from "remodules";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { MemoryRouter, Route, Switch } from "react-router";
 
-import createReroute from ".";
+import createReroutes from ".";
 
 afterEach(cleanup);
 
-describe("exports a createReroute function, that", () => {
+describe("exports a createReroutes function, that", () => {
   it("returns an object", () => {
-    expect(createReroute).toBeInstanceOf(Function);
-    expect(createReroute("test")).toBeInstanceOf(Object);
+    expect(createReroutes).toBeInstanceOf(Function);
+    expect(createReroutes("test")).toBeInstanceOf(Object);
   });
 
-  describe("returned object has a reroute property, that", () => {
+  describe("returned object has a reroutes property, that", () => {
     it("is an object", () => {
-      expect(createReroute("test").reroute).toBeInstanceOf(Object);
+      expect(createReroutes("test").reroutes).toBeInstanceOf(Object);
     });
 
     describe("has a selectors property, that", () => {
@@ -39,13 +39,13 @@ describe("exports a createReroute function, that", () => {
         "hash",
         "state",
       ] as const)("selects %s property of the state", (selector) => {
-        const { reroute, useReroute } = createReroute("test");
+        const { reroutes, useReroutes } = createReroutes("test");
 
-        expect(reroute.selectors[selector]).toBeInstanceOf(Function);
+        expect(reroutes.selectors[selector]).toBeInstanceOf(Function);
 
         const Test = () => {
-          useReroute();
-          const state = useSelector(reroute.selectors[selector]);
+          useReroutes();
+          const state = useSelector(reroutes.selectors[selector]);
 
           return <div data-testid="test">{String(state)}</div>;
         };
@@ -73,17 +73,17 @@ describe("exports a createReroute function, that", () => {
     });
   });
 
-  describe("returned object has a useReroute property, that", () => {
+  describe("returned object has a useReroutes property, that", () => {
     it("is a function", () => {
-      expect(createReroute("test").useReroute).toBeInstanceOf(Function);
+      expect(createReroutes("test").useReroutes).toBeInstanceOf(Function);
     });
 
     it("ensures base is set to current route", () => {
-      const { reroute, useReroute } = createReroute("test");
+      const { reroutes, useReroutes } = createReroutes("test");
 
       const Test = () => {
-        useReroute();
-        const base = useSelector(reroute.selectors.base);
+        useReroutes();
+        const base = useSelector(reroutes.selectors.base);
 
         return <div data-testid="test">{base}</div>;
       };
@@ -114,20 +114,20 @@ describe("exports a createReroute function, that", () => {
 
   describe("returned object has a createLocationChangedMatcher property, that", () => {
     it("is a function", () => {
-      expect(createReroute("test").createLocationChangedMatcher).toBeInstanceOf(
-        Function
-      );
+      expect(
+        createReroutes("test").createLocationChangedMatcher
+      ).toBeInstanceOf(Function);
     });
 
     describe("returns a matcher function, that", () => {
       const testPath = "/test";
-      const { reroute, createLocationChangedMatcher } = createReroute("test");
+      const { reroutes, createLocationChangedMatcher } = createReroutes("test");
       const matcher = createLocationChangedMatcher(testPath);
 
       it("does not match a route change to a different path", () => {
         expect(
           matcher(
-            reroute.actions.locationChanged({
+            reroutes.actions.locationChanged({
               action: "INIT",
               location: {
                 pathname: "/not-test",
@@ -143,7 +143,7 @@ describe("exports a createReroute function, that", () => {
       it("matches a route change to the given path", () => {
         expect(
           matcher(
-            reroute.actions.locationChanged({
+            reroutes.actions.locationChanged({
               action: "INIT",
               location: {
                 pathname: testPath,
@@ -160,8 +160,8 @@ describe("exports a createReroute function, that", () => {
 });
 
 describe("application flow tests", () => {
-  const { reroute, useReroute, createLocationChangedMatcher } =
-    createReroute("test");
+  const { reroutes, useReroutes, createLocationChangedMatcher } =
+    createReroutes("test");
 
   const Example = () => {
     return <div>Example</div>;
@@ -171,28 +171,28 @@ describe("application flow tests", () => {
     const dispatch = useDispatch();
     return (
       <nav>
-        <button onClick={() => dispatch(reroute.actions.push("/example"))}>
+        <button onClick={() => dispatch(reroutes.actions.push("/example"))}>
           Push /example
         </button>
-        <button onClick={() => dispatch(reroute.actions.push("/test"))}>
+        <button onClick={() => dispatch(reroutes.actions.push("/test"))}>
           Push /test
         </button>
-        <button onClick={() => dispatch(reroute.actions.push("/test2"))}>
+        <button onClick={() => dispatch(reroutes.actions.push("/test2"))}>
           Push /test2
         </button>
-        <button onClick={() => dispatch(reroute.actions.push("/test3"))}>
+        <button onClick={() => dispatch(reroutes.actions.push("/test3"))}>
           Push /test3
         </button>
-        <button onClick={() => dispatch(reroute.actions.replace("/replaced"))}>
+        <button onClick={() => dispatch(reroutes.actions.replace("/replaced"))}>
           Replace /replaced
         </button>
-        <button onClick={() => dispatch(reroute.actions.go(-1))}>Go -1</button>
-        <button onClick={() => dispatch(reroute.actions.go(1))}>Go +1</button>
-        <button onClick={() => dispatch(reroute.actions.go(2))}>Go +2</button>
-        <button onClick={() => dispatch(reroute.actions.goBack())}>
+        <button onClick={() => dispatch(reroutes.actions.go(-1))}>Go -1</button>
+        <button onClick={() => dispatch(reroutes.actions.go(1))}>Go +1</button>
+        <button onClick={() => dispatch(reroutes.actions.go(2))}>Go +2</button>
+        <button onClick={() => dispatch(reroutes.actions.goBack())}>
           Go back
         </button>
-        <button onClick={() => dispatch(reroute.actions.goForward())}>
+        <button onClick={() => dispatch(reroutes.actions.goForward())}>
           Go forward
         </button>
       </nav>
@@ -200,8 +200,8 @@ describe("application flow tests", () => {
   };
 
   const LocationDisplay = () => {
-    const action = useSelector(reroute.selectors.action);
-    const location = useSelector(reroute.selectors.location);
+    const action = useSelector(reroutes.selectors.action);
+    const location = useSelector(reroutes.selectors.location);
 
     return (
       <div>
@@ -214,7 +214,7 @@ describe("application flow tests", () => {
   const store = createDynamicStore({ reducer: (state = {}) => state });
 
   const Wrapper = ({ children }: PropsWithChildren<{}>) => {
-    useReroute();
+    useReroutes();
 
     return <>{children}</>;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,14 +10,14 @@ import { pathToRegexp } from "path-to-regexp";
 
 type LocationChangeAction = Action | "INIT";
 
-type RerouteState = {
+type ReroutesState = {
   base: string;
   action: LocationChangeAction | null;
   location: Location;
   transitioning: boolean;
 };
 
-const initialState: RerouteState = {
+const initialState: ReroutesState = {
   action: null,
   base: "/",
   location: {
@@ -29,7 +29,7 @@ const initialState: RerouteState = {
   transitioning: false,
 };
 
-const baseName = "@@reroute";
+const baseName = "@@reroutes";
 
 const createHistoryChannel = (history: History) => {
   return eventChannel<{ location: Location; action: LocationChangeAction }>(
@@ -47,9 +47,9 @@ const pathJoin = (...paths: string[]) => {
   return paths.join("/").replace(/\/+/g, "/");
 };
 
-const createReroute = (key: string) => {
+const createReroutes = (key: string) => {
   const name = `${baseName}/${key}`;
-  const reroute = createModule({
+  const reroutes = createModule({
     name,
     initialState,
     reducers: {
@@ -168,8 +168,8 @@ const createReroute = (key: string) => {
   ) => {
     return (
       action: AnyAction
-    ): action is ReturnType<typeof reroute.actions.locationChanged> => {
-      const isLocationChanged = reroute.actions.locationChanged.match(action);
+    ): action is ReturnType<typeof reroutes.actions.locationChanged> => {
+      const isLocationChanged = reroutes.actions.locationChanged.match(action);
 
       return (
         isLocationChanged &&
@@ -180,8 +180,8 @@ const createReroute = (key: string) => {
     };
   };
 
-  const useReroute = () => {
-    useModule(reroute);
+  const useReroutes = () => {
+    useModule(reroutes);
     const dispatch = useDispatch();
 
     const { path } = useRouteMatch();
@@ -190,12 +190,12 @@ const createReroute = (key: string) => {
     const pathRef = useRef<string | null>(null);
 
     if (pathRef.current !== path) {
-      dispatch(reroute.actions.takeRoot({ base: path, history }));
+      dispatch(reroutes.actions.takeRoot({ base: path, history }));
       pathRef.current = path;
     }
   };
 
-  return { reroute, useReroute, createLocationChangedMatcher };
+  return { reroutes, useReroutes, createLocationChangedMatcher };
 };
 
-export default createReroute;
+export default createReroutes;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     minify: "terser",
     lib: {
       entry: resolve(__dirname, "src/index.ts"),
-      name: "Reroute",
+      name: "Reroutes",
       formats: ["es", "umd", "iife"],
     },
     rollupOptions: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     coverage: {
-      enabled: true,
       reporter: ["lcovonly", "text"],
       reportsDirectory: "coverage",
     },


### PR DESCRIPTION
- checking if this name will be allowed by npm

- **Please check if the PR fulfills these requirements**

* [x] The commit messages follow our [contribution guidelines](/CONTRIBUTING.md)
* [x] Your contributions follows out [Code of Conduct](/CODE_OF_CONDUCT.md)
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Name changes from `reroute` to `reroutes`.

- **Other information**:

NPM forbids names that are too familiar to other packages and apparently `reroute` is a match for `re-route`, which already exists, so here's to hoping `rero-utes` isn't also an existing package and this change goes through well.
